### PR TITLE
Don't automatically start server, add button to do so

### DIFF
--- a/lambda_handler.go
+++ b/lambda_handler.go
@@ -57,6 +57,32 @@ func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 		}, nil
 	}
 
+	// Instance not running, either print out the form to start it (for a GET) or actually start it (for a POST).
+	if request.HTTPMethod == "GET" {
+		body := `
+			<html>
+				<body>
+					<p>The server isn't running yet. Would you like to start it?</p>
+					<form action="">
+						<input type="submit" value="Start instance"/>
+					</form>
+				</body>
+			</html>
+		`
+		return events.APIGatewayProxyResponse{
+			Body:       body,
+			StatusCode: 200,
+		}, nil
+	}
+
+	// We should only get GET or POST requests
+	if request.HTTPMethod != "POST" {
+		return events.APIGatewayProxyResponse{
+			Body:       fmt.Sprint("Unrecognized HTTP method: %s", request.HTTPMethod),
+			StatusCode: 200,
+		}, nil
+	}
+
 	fmt.Printf("starting instance %s\n", instId)
 	_, err = client.StartInstances(&ec2.StartInstancesInput{
 		InstanceIds: []*string{


### PR DESCRIPTION
This changes the default behavior of loading the lambda to just printing out the status of the server. In the case that the server isn't running, it adds a button to the page which the user can use to start the server.

Testing plan: ...live?