### PR TITLE
Add a favicon and title to the status page

### DIFF
--- a/lambda_handler.go
+++ b/lambda_handler.go
@@ -61,6 +61,10 @@ func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 	if request.HTTPMethod == "GET" {
 		body := `
 			<html>
+				<head>
+					<title>Factorio Server Starter</title>
+					<link rel="icon" type="image/x-icon" href="https://www.factorio.com/static/img/favicon.ico"/>
+				</head>
 				<body>
 					<p>The server isn't running yet. Would you like to start it?</p>
 					<form action="" method="post">


### PR DESCRIPTION
The favicon is taken from the Factorio blog. I'm not sure if CORS will allow this, but if it doesn't we can change this to just include the icon data inline in the HTML.